### PR TITLE
touch the file and the appropriate sub-directory, not necessarily the root base backup dir

### DIFF
--- a/src/Tradesy/Innobackupex/S3/Local/Download.php
+++ b/src/Tradesy/Innobackupex/S3/Local/Download.php
@@ -83,6 +83,7 @@ class Download implements LoadInterface
                     "base_dir" => $key_prefix . DIRECTORY_SEPARATOR . $filename,
                     "debug" => true,
                     "before" => function (Command $command) use ($path_to, $key_prefix) {
+                        # swap out s3 base directory for local target directory
                         $target_file_name = substr_replace($command['Key'], $path_to, 0, strlen($key_prefix));
 
                         # make sure any nested dirs exist first


### PR DESCRIPTION
### Description
Current implementation to touch files does not take into account any sub directories relative to `getBaseBackupDirectory()` (/tmp/backup). This PR makes sure any required sub-directories exists and then touches the file in the correct location.

ie: currently touching `/tmp/backups/admin_label.frm.xbcrypt`, but really want `/tmp/backups/full_backup_06-11-2019--00-15-05/staging/admin_label.frm.xbcrypt`

### Example
```
/var/lib/jenkins/workspace/Deploy_Branches/tradesy-cron/vendor/tradesy/innobackupex/src/Tradesy/Innobackupex/S3/Local/Download.php:93:
array(5) {
  'command->toArray' =>
  array(3) {
    'Bucket' =>
    string(44) "percona-mysql-innobackupex-backups-encrypted"
    'Key' =>
    string(85) "06-11-2019--00-15-05/full_backup_06-11-2019--00-15-05/staging/admin_label.frm.xbcrypt"
    '@http' =>
    array(1) {
      'sink' =>
      string(77) "/tmp/backups/full_backup_06-11-2019--00-15-05/staging/admin_label.frm.xbcrypt"
    }
  }
  'path_to' =>
  string(12) "/tmp/backups"
  'key_prefix' =>
  string(20) "06-11-2019--00-15-05"
  '$command[\'Key\']' =>
  string(85) "06-11-2019--00-15-05/full_backup_06-11-2019--00-15-05/staging/admin_label.frm.xbcrypt"
  '$target_file_name' =>
  string(77) "/tmp/backups/full_backup_06-11-2019--00-15-05/staging/admin_label.frm.xbcrypt"
}
Transferring s3://percona-mysql-innobackupex-backups-encrypted/06-11-2019--00-15-05/full_backup_06-11-2019--00-15-05/staging/admin_label.frm.xbcrypt -> /tmp/backups/full_backup_06-11-2019--00-15-05/staging/admin_label.frm.xbcrypt (GetObject)
```