### PR TITLE
Use passed in values for parallel

### DIFF
--- a/src/Tradesy/Innobackupex/Backup/AbstractBackup.php
+++ b/src/Tradesy/Innobackupex/Backup/AbstractBackup.php
@@ -129,7 +129,7 @@ abstract class AbstractBackup
         EncryptionConfiguration $enc_config = null,
         $compress = false,
         $compress_threads = 100,
-        $paralle_threads = 100,
+        $parallel_threads = 100,
         $encrypt_threads = 100,
         $memory = "1G",
         $base_backup_directory = "/tmp",
@@ -141,7 +141,7 @@ abstract class AbstractBackup
         $this->encryption_configuration = $enc_config;
         $this->compress = $compress;
         $this->compress_threads = $compress_threads;
-        $this->parallel_threads = $paralle_threads;
+        $this->parallel_threads = $parallel_threads;
         $this->encrypt_threads = $encrypt_threads;
         $this->memory = $memory;
         $this->base_backup_directory = $base_backup_directory;

--- a/src/Tradesy/Innobackupex/Backup/Full.php
+++ b/src/Tradesy/Innobackupex/Backup/Full.php
@@ -54,7 +54,7 @@ class Full extends AbstractBackup
             " --password={MYSQL_PASSWORD}" .
             " --host=" . $host .
             " --port=" . $port .
-            " --parallel=100" .
+            " --parallel=" . $this->parallel_threads .
             " --no-timestamp" .
             ($this->getCompress() ? 
                 " --compress  --compress-threads=" . $this->compress_threads : "") .

--- a/src/Tradesy/Innobackupex/Backup/Incremental.php
+++ b/src/Tradesy/Innobackupex/Backup/Incremental.php
@@ -58,7 +58,7 @@ class Incremental extends AbstractBackup
             " --password={MYSQL_PASSWORD}" .
             " --host=" . $host .
             " --port=" . $port .
-            " --parallel=100" .
+            " --parallel=" . $this->parallel_threads .
             " --no-timestamp" .
             ($this->getCompress() ?
                 " --compress --compress-threads=" . $this->compress_threads : "") .


### PR DESCRIPTION
This PR replaces the hard-coded value of 100 for `--parallel` flag and instead uses the passed in values during construction time.